### PR TITLE
Replace border-sidebar-border with standard neutral tokens

### DIFF
--- a/resources/js/pages/HorizonDashboard.vue
+++ b/resources/js/pages/HorizonDashboard.vue
@@ -78,7 +78,7 @@ usePoll(props.pollingInterval, {
     >
         <!-- Header Section -->
         <section
-            class="rounded-lg border border-sidebar-border/70 bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-800 p-6 text-white shadow-2xl dark:from-neutral-900 dark:via-black dark:to-neutral-950"
+            class="rounded-lg border border-neutral-200/70 bg-gradient-to-br from-neutral-950 via-neutral-900 to-neutral-800 p-6 text-white shadow-2xl dark:border-neutral-800/70 dark:from-neutral-900 dark:via-black dark:to-neutral-950"
         >
             <p class="text-sm tracking-[0.35em] text-neutral-400 uppercase">
                 Queue Management
@@ -96,7 +96,7 @@ usePoll(props.pollingInterval, {
 
         <!-- Horizon panel -->
         <div
-            class="rounded-lg border border-sidebar-border/70 bg-white/80 backdrop-blur dark:bg-black/40"
+            class="rounded-lg border border-neutral-200/70 bg-white/80 backdrop-blur dark:border-neutral-800/70 dark:bg-black/40"
         >
             <!-- Tabs -->
             <div


### PR DESCRIPTION
## Summary
- Replaces the non-standard `border-sidebar-border/70` token with `border-neutral-200/70` + `dark:border-neutral-800/70` on both panels in `HorizonDashboard.vue`
- Makes the package self-sufficient so the panels render with visible borders on a plain Laravel install without a starter kit

Fixes #4

## Test plan
- [x] `laravel new` a fresh app and install the package from this branch — confirm both panels have visible borders in light and dark mode
- [x] Verify the dashboard still renders correctly on an app that uses Breeze/Jetstream (where `--color-sidebar-border` is defined upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)