### PR TITLE
Auto-inject Tailwind @source directive in horizon-ui:install

### DIFF
--- a/src/HorizonUiServiceProvider.php
+++ b/src/HorizonUiServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Negoziator\HorizonUi;
 
+use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Gate;
 use Negoziator\HorizonUi\Commands\AutoPauseHorizonSupervisors;
@@ -12,6 +13,8 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class HorizonUiServiceProvider extends PackageServiceProvider
 {
+    private const string TAILWIND_SOURCE_DIRECTIVE = "@source '../js/vendor/horizon-ui/**/*.vue';";
+
     public function configurePackage(Package $package): void
     {
         $package
@@ -25,10 +28,65 @@ class HorizonUiServiceProvider extends PackageServiceProvider
                     ->endWith(function ($cmd): void {
                         $cmd->call('vendor:publish', ['--tag' => 'horizon-ui-vue']);
                         $cmd->newLine();
+                        $this->injectTailwindSource($cmd);
+                        $cmd->newLine();
                         $cmd->info('Horizon UI installed. Dashboard: '.url(config('horizon-ui.path', 'horizon-ui')));
                         $cmd->comment('Next: update your Inertia resolve function in app.ts — see the README for the snippet.');
                     });
             });
+    }
+
+    protected function injectTailwindSource(Command $command): void
+    {
+        $cssPath = resource_path('css/app.css');
+        $directive = self::TAILWIND_SOURCE_DIRECTIVE;
+
+        if (! is_file($cssPath)) {
+            $command->error('Could not find resources/css/app.css to register the package\'s Vue files.');
+            $command->line('   Add this directive to your Tailwind v4 entry point, or Horizon UI will render unstyled:');
+            $command->newLine();
+            $command->line("   {$directive}");
+
+            return;
+        }
+
+        $contents = file_get_contents($cssPath);
+
+        if (preg_match('/@source\s+[\'"][^\'"]*js\/vendor\/horizon-ui[^\'"]*[\'"]/', $contents) === 1) {
+            $command->info('Tailwind @source directive already present in resources/css/app.css.');
+
+            return;
+        }
+
+        if (preg_match('/^\s*@import\s+[\'"]tailwindcss[\'"][^;]*;/m', $contents) !== 1) {
+            $command->warn('resources/css/app.css has no @import "tailwindcss" line — is this a Tailwind v4 entry point?');
+            $command->line("   Add manually where Tailwind scans sources: {$directive}");
+
+            return;
+        }
+
+        if (! $command->confirm('Add Tailwind @source directive to resources/css/app.css so Horizon UI components are styled?', true)) {
+            $command->warn("Skipped. Add manually to your Tailwind entry point: {$directive}");
+
+            return;
+        }
+
+        $updated = preg_replace(
+            '/(^\s*@import\s+[\'"]tailwindcss[\'"][^;]*;)/m',
+            "\$1\n{$directive}",
+            $contents,
+            1,
+        );
+
+        if ($updated === null || $updated === $contents) {
+            $command->error('Failed to inject @source directive into resources/css/app.css.');
+            $command->line("   Add manually: {$directive}");
+
+            return;
+        }
+
+        file_put_contents($cssPath, $updated);
+        $command->info('Registered Horizon UI Vue files in resources/css/app.css.');
     }
 
     public function packageRegistered(): void

--- a/tests/Feature/InstallCommandTest.php
+++ b/tests/Feature/InstallCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Negoziator\HorizonUi\Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    $this->cssPath = resource_path('css/app.css');
+    $this->publishedVueDir = resource_path('js/vendor/horizon-ui');
+    File::ensureDirectoryExists(dirname($this->cssPath));
+});
+
+afterEach(function (): void {
+    if (is_file($this->cssPath)) {
+        unlink($this->cssPath);
+    }
+    if (is_dir($this->publishedVueDir)) {
+        File::deleteDirectory($this->publishedVueDir);
+    }
+});
+
+it('injects the @source directive after @import tailwindcss', function (): void {
+    file_put_contents(
+        $this->cssPath,
+        "@import \"tailwindcss\";\n\nbody { margin: 0; }\n",
+    );
+
+    $this->artisan('horizon-ui:install')
+        ->expectsConfirmation(
+            'Add Tailwind @source directive to resources/css/app.css so Horizon UI components are styled?',
+            'yes',
+        )
+        ->assertSuccessful();
+
+    $contents = file_get_contents($this->cssPath);
+    expect($contents)->toContain("@source '../js/vendor/horizon-ui/**/*.vue';");
+    expect($contents)->toContain('@import "tailwindcss";');
+    // Directive must appear after the @import line, not before.
+    expect(strpos($contents, '@source'))->toBeGreaterThan(strpos($contents, '@import'));
+});
+
+it('skips injection when the user declines the confirmation', function (): void {
+    file_put_contents(
+        $this->cssPath,
+        "@import \"tailwindcss\";\n",
+    );
+
+    $this->artisan('horizon-ui:install')
+        ->expectsConfirmation(
+            'Add Tailwind @source directive to resources/css/app.css so Horizon UI components are styled?',
+            'no',
+        )
+        ->assertSuccessful();
+
+    $contents = file_get_contents($this->cssPath);
+    expect($contents)->not->toContain('@source');
+});
+
+it('does not duplicate the @source directive on re-run', function (): void {
+    $initial = "@import \"tailwindcss\";\n@source '../js/vendor/horizon-ui/**/*.vue';\n";
+    file_put_contents($this->cssPath, $initial);
+
+    $this->artisan('horizon-ui:install --no-interaction')->assertSuccessful();
+
+    $contents = file_get_contents($this->cssPath);
+    expect(substr_count($contents, 'js/vendor/horizon-ui'))->toBe(1);
+});
+
+it('recognises an existing directive written with double quotes', function (): void {
+    $initial = "@import \"tailwindcss\";\n@source \"../js/vendor/horizon-ui/**/*.vue\";\n";
+    file_put_contents($this->cssPath, $initial);
+
+    $this->artisan('horizon-ui:install --no-interaction')->assertSuccessful();
+
+    $contents = file_get_contents($this->cssPath);
+    expect(substr_count($contents, 'js/vendor/horizon-ui'))->toBe(1);
+});
+
+it('shows an error when resources/css/app.css is missing', function (): void {
+    // Make sure no file is present.
+    if (is_file($this->cssPath)) {
+        unlink($this->cssPath);
+    }
+
+    $this->artisan('horizon-ui:install --no-interaction')
+        ->expectsOutputToContain('Could not find resources/css/app.css')
+        ->assertSuccessful();
+});
+
+it('warns and skips injection when app.css has no @import tailwindcss', function (): void {
+    file_put_contents($this->cssPath, "body { color: red; }\n");
+
+    $this->artisan('horizon-ui:install --no-interaction')
+        ->expectsOutputToContain('no @import "tailwindcss"')
+        ->assertSuccessful();
+
+    $contents = file_get_contents($this->cssPath);
+    expect($contents)->not->toContain('@source');
+});


### PR DESCRIPTION
## Summary
- Implements the short-term fix described in #6
- `horizon-ui:install` now detects `resources/css/app.css`, asks the user for confirmation, and injects `@source '../js/vendor/horizon-ui/**/*.vue';` right after `@import "tailwindcss";`
- Idempotent on re-runs (substring match handles single/double quotes)
- Falls back to a clear, copy-pasteable error when `app.css` is missing, and a warning when it doesn't look like a Tailwind v4 entry point — replacing the previous silent failure
- Six new feature tests covering inject, decline, idempotency (both quote styles), missing file, and missing `@import "tailwindcss"`

This is the short-term fix proposed in #6. It mutates the consumer's `app.css`, which is unusual for a Laravel package and has the drawbacks discussed in the issue. The longer-term direction (ship styling from the package itself, à la Filament/Nova) would replace this entirely. Happy to follow up with a PR for that direction if preferred — see #6 for details.

Fixes #6

## Test plan
- [x] `vendor/bin/pest tests/Feature/InstallCommandTest.php` passes
- [x] On a fresh `laravel new` app: `composer require` this branch, run `php artisan horizon-ui:install`, confirm at the prompt, then verify `resources/css/app.css` contains the `@source` line and the dashboard renders styled
- [x] Re-run `horizon-ui:install` on the same app: confirm no duplicate `@source` line is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)