### PR TITLE
Use solid panel backgrounds and document Tailwind v4 dark variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ The bundled Vue components require `reka-ui` and `lucide-vue-next`. Install them
 npm install reka-ui lucide-vue-next
 ```
 
+### Tailwind v4 setup
+
+The bundled components use `dark:` utility variants, but Tailwind v4 does not register a `dark` variant out of the box — you have to declare one yourself. Add it to your Tailwind entry point (typically `resources/css/app.css`) so the dashboard responds to OS-level dark-mode preference:
+
+```css
+@import "tailwindcss";
+@custom-variant dark (@media (prefers-color-scheme: dark));
+```
+
+If your app uses a class-based dark-mode toggle (`<html class="dark">`) instead, declare the variant accordingly:
+
+```css
+@custom-variant dark (&:where(.dark, .dark *));
+```
+
+Without one of these declarations, the dashboard renders in light mode regardless of OS preference.
+
 ### Inertia page resolution
 
 The `HorizonDashboard` Inertia component is placed in `resources/js/vendor/horizon-ui/pages/` (done automatically by `horizon-ui:install`). Vite's `import.meta.glob` doesn't scan that path by default, so you need to add it to your resolve function in `app.ts` (or `app.js`):

--- a/resources/js/pages/HorizonDashboard.vue
+++ b/resources/js/pages/HorizonDashboard.vue
@@ -96,7 +96,7 @@ usePoll(props.pollingInterval, {
 
         <!-- Horizon panel -->
         <div
-            class="rounded-lg border border-sidebar-border/70 bg-white/80 backdrop-blur dark:bg-black/40"
+            class="rounded-lg border border-sidebar-border/70 bg-white dark:bg-neutral-900"
         >
             <!-- Tabs -->
             <div


### PR DESCRIPTION
## Summary
- Resolves both styling issues described in #10
- Replaces the translucent `bg-white/80 backdrop-blur dark:bg-black/40` on the content panel with solid `bg-white dark:bg-neutral-900` so the panel renders correctly on a plain Laravel install regardless of the consumer's body styling
- Drops `backdrop-blur` since it's a no-op once the background is fully opaque
- Adds a *Tailwind v4 setup* section to the README explaining the required `@custom-variant dark` declaration (covering both OS-preference and class-based dark-mode strategies)

Resolves #10

## Test plan
- [ ] On a fresh `laravel new` app: install this branch, set OS to dark mode, and verify the dashboard renders in dark mode with a readable solid panel background
- [ ] Toggle OS back to light mode and verify the panel renders white on the page
- [ ] On an app that uses a class-based dark toggle: confirm the README's `&:where(.dark, .dark *)` snippet works

🤖 Generated with [Claude Code](https://claude.com/claude-code)